### PR TITLE
Modifying README.md to reflect the issue where Windows version of Patari crashes on playing any song.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ I love Patari and support their vision. So I made this app in my free time.
 - [Mac OS X](dist/patari-osx.zip?raw=true)
 - [Windows](dist/patari-win.zip?raw=true)
 
+## Issues
+- If the Windows version crashes on playing any song, please set the compatibility mode for *Patari.exe* to Windows 7. The bug is currently under investigation.
 
 ## Contribute
 


### PR DESCRIPTION
Windows version of Patari has a bug, where it crashes on playing any song. This pull request updates the README.md to suggest a temporary workaround for this issue, until a permanent solution is investigated.
